### PR TITLE
feat: addLabel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { addBearerHeader, authentication } from "./authentication";
+import { addLabel } from "./updates/addLabel";
 import { createIssue } from "./creates/createIssue";
 import { createIssueMove } from "./creates/createIssueMove";
 import { newComment } from "./triggers/comment";
@@ -44,6 +45,9 @@ const App = {
     [createAttachmentLinkIntercom.key]: createAttachmentLinkIntercom,
     [createAttachmentLinkURL.key]: createAttachmentLinkURL,
   },
+  updates: {
+    [addLabel.key]: addLabel,
+  }
   triggers: {
     [newIssue.key]: newIssue,
     [updatedIssue.key]: updatedIssue,

--- a/src/updates/addLabel.ts
+++ b/src/updates/addLabel.ts
@@ -1,0 +1,105 @@
+import { Bundle, ZObject } from "zapier-platform-core";
+
+interface AddLabelRequestResponse {
+  data?: { issueUpdate: { issue: { url: string }; success: boolean } };
+  errors?: {
+    message: string;
+    extensions?: {
+      userPresentableMessage?: string;
+    };
+  }[];
+}
+
+const addLabelRequest = async (z: ZObject, bundle: Bundle) => {
+  const variables = {
+    issueId: bundle.inputData.issue_id,
+    labelId: bundle.inputData.label_id,
+  };
+
+  const query = `
+    mutation IssueUpdate(
+      $issueId: String!,
+      $labelId: String!
+    ) {
+      issueUpdate(
+        id: $issueId,
+        input: {
+          labelIds: [$labelId]
+        }
+      ) {
+        success
+        issue {
+          id
+          title
+          labels { 
+            nodes { id, name }
+          }
+        }
+      }
+    }`;
+
+  const response = await z.request({
+    url: "https://api.linear.app/graphql",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      authorization: bundle.authData.api_key,
+    },
+    body: {
+      query,
+      variables,
+    },
+    method: "POST",
+  });
+
+  const data = response.json as AddLabelRequestResponse;
+
+  if (data.errors && data.errors.length) {
+    const error = data.errors[0];
+    throw new z.errors.Error(
+      (error.extensions && error.extensions.userPresentableMessage) || error.message,
+      "invalid_input",
+      400
+    );
+  }
+
+  if (data.data && data.data.issueUpdate && data.data.issueUpdate.success) {
+    return data.data.issueUpdate.issue;
+  } else {
+    const error = data.errors ? data.errors[0].message : "Something went wrong";
+    throw new z.errors.Error(`Failed to create an issue`, error, 400);
+  }
+};
+
+export const addLabel = {
+  key: "add_label",
+
+  display: {
+    hidden: false,
+    important: true,
+    description: "Add label to Linear issue",
+    label: "Add label",
+  },
+
+  noun: "Issue",
+
+  operation: {
+    perform: addLabelRequest,
+
+    inputFields: [
+      {
+        required: true,
+        label: "Issue",
+        key: "issue_id",
+        helpText: "The issue to add the label to",
+      },
+      {
+        required: true,
+        label: "Label",
+        helpText: "The label to add",
+        key: "label_id",
+      },
+    ],
+    sample: { data: { issueUpdate: { success: true } } },
+  },
+};


### PR DESCRIPTION
# Why

I would like to enforce the addition of the eng oncall label for cards that are in the international eng oncall team (and why not use this as well in the regular eng oncall team).

# Test

I have not really tested this, I just tested the graphql query and it was working fine.
I don't want to spend too much time trying to have a working setup that would allow me to test this, could you review this and help me deploy it?