### PR TITLE
issueAttachments: return additional information

### DIFF
--- a/src/searches/issueAttachments.ts
+++ b/src/searches/issueAttachments.ts
@@ -29,6 +29,9 @@ interface issueAttachmentsRequestResponse {
           attachments {
             nodes {
               metadata
+              title
+              subtitle
+              url
             }
           }
         }


### PR DESCRIPTION
For the Mind oncall Zap, I'd like to get access to more info than metadata when looking for an issue's attachments. It will help for:
- potentially retrieve intercom discussion based on URL (instead of meta)
- easier debugging